### PR TITLE
Ignore differences in whitespace.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "^0.14.2"
   },
   "dependencies": {
+    "collapse-white-space": "^1.0.0",
     "react-addons-test-utils": "^0.14.2",
     "react-element-to-jsx-string": "^2.1.0"
   },

--- a/src/jsx-chai.js
+++ b/src/jsx-chai.js
@@ -1,5 +1,6 @@
 import {isElement} from 'react-addons-test-utils'
 import reactElementToJSXString from 'react-element-to-jsx-string'
+import collapse from 'collapse-white-space'
 
 export default function jsxChai({Assertion}, {inspect}) {
 
@@ -18,8 +19,8 @@ export default function jsxChai({Assertion}, {inspect}) {
           return _super.apply(this, arguments)
         }
 
-        const expected = reactElementToJSXString(jsx)
-        const actual = reactElementToJSXString(this._obj)
+        const expected = collapse(reactElementToJSXString(jsx))
+        const actual = collapse(reactElementToJSXString(this._obj))
 
         return func.call(this, {jsx, expected, actual})
       }


### PR DESCRIPTION
Inspired by [algolia's expect-jsx](https://github.com/algolia/expect-jsx/blob/fc536f795043a077b04aafe79e6a19433c590300/index.js#L3) this change collapses whitespace so that 

``` jsx
expect(
  <div>
    <span>
      <a>
        Foo
      </a>
    </span>
  </div>
).to.include(
  <a>
    Foo
  </a>
)
```

Passes
