### PR TITLE
Bump to React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bkonkle/jsx-chai#readme",
   "peerDependencies": {
     "chai": "^3.4.0",
-    "react": "^15.0.1"
+    "react": "^0.14.0 || ^15.0.0-0"
   },
   "dependencies": {
     "collapse-white-space": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   "homepage": "https://github.com/bkonkle/jsx-chai#readme",
   "peerDependencies": {
     "chai": "^3.4.0",
-    "react": "^0.14.2"
+    "react": "^15.0.1"
   },
   "dependencies": {
     "collapse-white-space": "^1.0.0",
-    "react-addons-test-utils": "^0.14.2",
-    "react-element-to-jsx-string": "^2.1.0"
+    "react-addons-test-utils": "^15.0.1",
+    "react-element-to-jsx-string": "^2.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.2",
@@ -52,6 +52,7 @@
     "gulp-sourcemaps": "^1.6.0",
     "istanbul": "^0.4.0",
     "mocha": "^2.3.3",
+    "react": "^15.0.1",
     "webpack": "^1.12.3"
   }
 }


### PR DESCRIPTION
This requires bumping react-element-to-jsx-string too (2.5.0 relies on React 15).

Closes #4.
